### PR TITLE
add actions environments

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build and deploy preview environment
         id: build-deploy-preview-environment
         run: |
-          terraform apply --auto-approve
+          terraform apply --auto-approve -var is_prod=${{ vars.IS_VERCEL_PROD }}
 
       - name: Terraform Output
         id: output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   deploy-production-environment:
     name: Deploy Production Environment
     runs-on: ubuntu-latest
+    environment: Production
     env:
       tfcWorkspaceName: nextra-docs
       tfcOrg: jhutchinson531
@@ -30,7 +31,7 @@ jobs:
       - name: Build and deploy pproduction environment
         id: build-deploy-production-environment
         run: |
-          terraform apply --auto-approve -var is_prod=true
+          terraform apply --auto-approve -var is_prod=${{ vars.IS_VERCEL_PROD }}
 
       - name: Terraform Output
         id: output

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "vercel_project" "nextra_docs" {
 output "vercel_project_id" {
   description = "Vercel project ID"
   value     = length(vercel_project.nextra_docs) > 0 ? vercel_project.nextra_docs[*].id : null
-  sensitive = true
+  sensitive = false
 }
 
 data "vercel_project_directory" "nextra_docs" {


### PR DESCRIPTION
## Details

Adding the `Production` environment to the repo so that it can be displayed on the home view

**[Fix]**: Previous commit updated the `vercel_project_id` output to be a tuple instead of the first value of that tuple. This was fixed using a temp change in f7401b62618f1c380175daa02e2cbe717fbaf8ce. The change is reverted here