### PR TITLE
add `prod_domain` output

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Get Preview URL
         id: get-preview-url
         run: |
-          PREVIEW_DOMAIN=$(terraform output -raw preview_url)
+          PREVIEW_DOMAIN=$(terraform output -raw preview_domain)
           PREVIEW_URL="https://$PREVIEW_DOMAIN"
 
           echo Preview environment deployed at: $PREVIEW_URL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.5.1
+          terraform_wrapper: false
           cli_config_credentials_token: ${{ secrets.TFC_API_TOKEN }}
 
       - name: Initialize Terraform Workspace
@@ -45,7 +46,7 @@ jobs:
       - name: Get Production URL
         id: get-prod-url
         run: |
-          PROD_DOMAIN=$(terraform output -raw preview_url)
+          PROD_DOMAIN=$(terraform output -raw prod_domain)
           PROD_URL="https://$PROD_DOMAIN"
 
           echo Production deployed at: $PROD_URL

--- a/main.tf
+++ b/main.tf
@@ -58,5 +58,5 @@ output "preview_domain" {
 
 output "prod_domain" {
   description = "Prod domain for Vercel project"
-  value       = is_prod ? vercel_deployment.nextra_docs.domains[0] : null
+  value       = is_prod ? element(vercel_deployment.nextra_docs.domains, 0) : null
 }

--- a/main.tf
+++ b/main.tf
@@ -58,5 +58,5 @@ output "preview_domain" {
 
 output "prod_domain" {
   description = "Prod domain for Vercel project"
-  value       = is_prod ? element(vercel_deployment.nextra_docs.domains, 0) : null
+  value       = var.is_prod ? vercel_deployment.nextra_docs.domains[0] : null
 }

--- a/main.tf
+++ b/main.tf
@@ -51,11 +51,12 @@ resource "vercel_deployment" "nextra_docs" {
   production  = var.is_prod
 }
 
-output "preview_url" {
+output "preview_domain" {
   description = "Preview URL for Vercel deployment"
   value = vercel_deployment.nextra_docs.url
 }
 
-output "domains" {
-  value = vercel_deployment.nextra_docs.domains
+output "prod_domain" {
+  description = "Prod domain for Vercel project"
+  value = is_prod ? vercel_deployment.nextra_docs.domains[0] : null
 }

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,8 @@ resource "vercel_project" "nextra_docs" {
 
 output "vercel_project_id" {
   description = "Vercel project ID"
-  value     = length(vercel_project.nextra_docs) > 0 ? vercel_project.nextra_docs[0].id : null
-  sensitive = false
+  value       = length(vercel_project.nextra_docs) > 0 ? vercel_project.nextra_docs[0].id : null
+  sensitive   = false
 }
 
 data "vercel_project_directory" "nextra_docs" {
@@ -53,10 +53,10 @@ resource "vercel_deployment" "nextra_docs" {
 
 output "preview_domain" {
   description = "Preview URL for Vercel deployment"
-  value = vercel_deployment.nextra_docs.url
+  value       = vercel_deployment.nextra_docs.url
 }
 
 output "prod_domain" {
   description = "Prod domain for Vercel project"
-  value = is_prod ? vercel_deployment.nextra_docs.domains[0] : null
+  value       = is_prod ? vercel_deployment.nextra_docs.domains[0] : null
 }


### PR DESCRIPTION
## Description

In order to display the prod URL, a new output `prod_domain` needs to be added which outputs the prod domain for the Vercel project.

- Add `prod_domain` output
- Fix release workflow by adding `terraform_wrapper: false`
- Format